### PR TITLE
🐛 Fix download and init on Windows filesystems

### DIFF
--- a/build/commands/download.ts
+++ b/build/commands/download.ts
@@ -12,7 +12,6 @@ const unpack = async (name: string, version: string) => {
     const cwd = process.cwd().split(sep).join(posix.sep)
 
     log.info(`Unpacking Firefox...`);
-    log.info(cwd)
     await execa("tar", ["-xvf", name, "-C", cwd]);
 
     moveSync(
@@ -118,4 +117,4 @@ export const download = async () => {
     data.on("end", () => {
         unpack(filename, version)
     })
-}A
+}

--- a/build/commands/download.ts
+++ b/build/commands/download.ts
@@ -1,7 +1,7 @@
 import axios from 'axios';
 import { bin_name, log } from '..';
 import fs, { existsSync, symlinkSync, writeFileSync } from 'fs';
-import { resolve } from 'path';
+import { posix, resolve, sep } from 'path';
 import execa from 'execa';
 import { dispatch } from '../dispatch';
 import { moveSync } from 'fs-extra';
@@ -9,12 +9,15 @@ import { moveSync } from 'fs-extra';
 const pjson = require("../../package.json");
 
 const unpack = async (name: string, version: string) => {
+    const cwd = process.cwd().split(sep).join(posix.sep)
+
     log.info(`Unpacking Firefox...`);
-    await execa("tar", ["-xvf", name, "-C", process.cwd()]);
+    log.info(cwd)
+    await execa("tar", ["-xvf", name, "-C", cwd]);
 
     moveSync(
-        resolve(process.cwd(), `firefox-${version.split("b")[0]}`),
-        resolve(process.cwd(), "src"),
+        resolve(cwd, `firefox-${version.split("b")[0]}`),
+        resolve(cwd, "src"),
         { overwrite: true }
     )
 
@@ -115,4 +118,4 @@ export const download = async () => {
     data.on("end", () => {
         unpack(filename, version)
     })
-}
+}A

--- a/build/commands/init.ts
+++ b/build/commands/init.ts
@@ -1,25 +1,33 @@
 import execa from "execa"
 import { existsSync, readFileSync } from "fs"
-import { resolve } from "path"
+import { posix, resolve, sep } from "path"
 import { log, bin_name } from ".."
 import { dispatch } from "../dispatch"
 
 export const init = async (directory: string) => {
+    if(process.platform == "win32") {
+        log.info("Init does not currently work on Windows filesystems, falling back to bash script. See issue: https://github.com/dothq/browser/issues/514");
+        await dispatch("windows-init.sh");
+        process.exit(-1);
+    } 
+
+    const cwd = process.cwd();
+
     log.info(`Initialising through Git...`)
     
-    const dir = resolve(process.cwd(), directory);
+    const dir = resolve(cwd, directory);
 
     if(!existsSync(dir)) {
         log.error(`Directory "${directory}" not found.\nCheck the directory exists and run |${bin_name} init| again.`)
     }
 
-    const version = readFileSync(resolve(process.cwd(), directory, "browser", "config", "version_display.txt"), "utf-8");
+    const version = readFileSync(resolve(cwd, directory, "browser", "config", "version_display.txt"), "utf-8");
 
     if(!version) log.error(`Directory "${directory}" not found.\nCheck the directory exists and run |${bin_name} init| again.`);
 
     await dispatch("git", ["init"], dir);
     await dispatch("git", ["checkout", "--orphan", version], dir);
-    await dispatch("git", ["add", "-f", "*"], dir);
+    await dispatch("git", ["add", "-f", "."], dir);
     await dispatch("git", ["commit", "-am", `"Firefox ${version}"`], dir);
     await dispatch("git", ["checkout", "-b", "dot"], dir);
-}
+} 

--- a/build/commands/init.ts
+++ b/build/commands/init.ts
@@ -19,7 +19,7 @@ export const init = async (directory: string) => {
 
     await dispatch("git", ["init"], dir);
     await dispatch("git", ["checkout", "--orphan", version], dir);
-    await dispatch("git", ["add", "-f", "*", ".*"], dir);
+    await dispatch("git", ["add", "-f", "*"], dir);
     await dispatch("git", ["commit", "-am", `"Firefox ${version}"`], dir);
     await dispatch("git", ["checkout", "-b", "dot"], dir);
 }

--- a/src/README.md
+++ b/src/README.md
@@ -1,3 +1,0 @@
-# Source code mountpoint
-
-This directory is for the browser code when it is mounted.

--- a/windows-init.sh
+++ b/windows-init.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+
+cd src
+git init
+git checkout --orphan ff
+echo "Adding source files to Git repo. This may take a while..."
+git add .
+git commit -am "Firefox"
+git checkout -b dot
+
+echo "Successfully set up src directory!"


### PR DESCRIPTION
Fixes https://github.com/dothq/browser-desktop/issues/249. 

**Changes:**
- Sanitizes paths to use POSIX-style separators
- Uses a separate script to initialize `src` on Windows