### PR TITLE
Enable SameSite cookie options by default

### DIFF
--- a/patches/modules-libpref-init-StaticPrefList-yaml.patch
+++ b/patches/modules-libpref-init-StaticPrefList-yaml.patch
@@ -1,0 +1,28 @@
+diff --git a/modules/libpref/init/StaticPrefList.yaml b/modules/libpref/init/StaticPrefList.yaml
+index 3156c49e142c9c0ff756b6adb5ef3d7ff0274554..a215837bb07e062163db22facf3c4d9b6d3e3efe 100644
+--- a/modules/libpref/init/StaticPrefList.yaml
++++ b/modules/libpref/init/StaticPrefList.yaml
+@@ -8222,7 +8222,7 @@
+ 
+ - name: network.cookie.sameSite.laxByDefault
+   type: bool
+-  value: @IS_NIGHTLY_BUILD@
++  value: true
+   mirror: always
+ 
+ # lax-by-default 2 minutes tollerance for unsafe methods. The value is in seconds.
+@@ -8233,12 +8233,12 @@
+ 
+ - name: network.cookie.sameSite.noneRequiresSecure
+   type: bool
+-  value: @IS_NIGHTLY_BUILD@
++  value: true
+   mirror: always
+ 
+ - name: network.cookie.sameSite.schemeful
+   type: bool
+-  value: @IS_NIGHTLY_BUILD@
++  value: true
+   mirror: always
+ 
+ - name: network.cookie.thirdparty.sessionOnly


### PR DESCRIPTION
Set `network.cookie.sameSite.laxByDefault`, `network.cookie.sameSite.noneRequiresSecure` and `network.cookie.sameSite.schemeful` to `true` by default to allign with [Chrome's rollout to stable channels in August 2020](https://www.chromium.org/updates/same-site).