### PR TITLE
🔒 Disable weaker ciphers

### DIFF
--- a/patches/modules-libpref-init-all-js.patch
+++ b/patches/modules-libpref-init-all-js.patch
@@ -1,0 +1,24 @@
+diff --git a/modules/libpref/init/all.js b/modules/libpref/init/all.js
+index 00c9edbc000b6f1ef5718412b749056442e20556..7c833265af4c96997855ee76c55d192936ea7e2a 100644
+--- a/modules/libpref/init/all.js
++++ b/modules/libpref/init/all.js
+@@ -48,16 +48,16 @@ pref("security.ssl3.ecdhe_rsa_chacha20_poly1305_sha256", true);
+ pref("security.ssl3.ecdhe_ecdsa_aes_256_gcm_sha384", true);
+ pref("security.ssl3.ecdhe_rsa_aes_256_gcm_sha384", true);
+ pref("security.ssl3.ecdhe_rsa_aes_128_sha", true);
+-pref("security.ssl3.ecdhe_ecdsa_aes_128_sha", true);
++pref("security.ssl3.ecdhe_ecdsa_aes_128_sha", false);
+ pref("security.ssl3.ecdhe_rsa_aes_256_sha", true);
+-pref("security.ssl3.ecdhe_ecdsa_aes_256_sha", true);
++pref("security.ssl3.ecdhe_ecdsa_aes_256_sha", false);
+ pref("security.ssl3.dhe_rsa_aes_128_sha", false);
+ pref("security.ssl3.dhe_rsa_aes_256_sha", false);
+ pref("security.ssl3.rsa_aes_128_sha", true);
+ pref("security.ssl3.rsa_aes_256_sha", true);
+ pref("security.ssl3.rsa_aes_128_gcm_sha256", true);
+ pref("security.ssl3.rsa_aes_256_gcm_sha384", true);
+-pref("security.ssl3.rsa_des_ede3_sha", true);
++pref("security.ssl3.rsa_des_ede3_sha", false);
+ 
+ pref("security.content.signature.root_hash",
+      "97:E8:BA:9C:F1:2F:B3:DE:53:CC:42:A4:E6:57:7E:D6:4D:F4:93:C2:47:B4:14:FE:A0:36:81:8D:38:23:56:0E");

--- a/patches/modules-libpref-init-all-js.patch
+++ b/patches/modules-libpref-init-all-js.patch
@@ -1,8 +1,8 @@
 diff --git a/modules/libpref/init/all.js b/modules/libpref/init/all.js
-index 00c9edbc000b6f1ef5718412b749056442e20556..7c833265af4c96997855ee76c55d192936ea7e2a 100644
+index 00c9edbc000b6f1ef5718412b749056442e20556..4e7f4dbca58fad15cef22080de5323557e4cbf1e 100644
 --- a/modules/libpref/init/all.js
 +++ b/modules/libpref/init/all.js
-@@ -48,16 +48,16 @@ pref("security.ssl3.ecdhe_rsa_chacha20_poly1305_sha256", true);
+@@ -48,9 +48,9 @@ pref("security.ssl3.ecdhe_rsa_chacha20_poly1305_sha256", true);
  pref("security.ssl3.ecdhe_ecdsa_aes_256_gcm_sha384", true);
  pref("security.ssl3.ecdhe_rsa_aes_256_gcm_sha384", true);
  pref("security.ssl3.ecdhe_rsa_aes_128_sha", true);
@@ -14,11 +14,3 @@ index 00c9edbc000b6f1ef5718412b749056442e20556..7c833265af4c96997855ee76c55d1929
  pref("security.ssl3.dhe_rsa_aes_128_sha", false);
  pref("security.ssl3.dhe_rsa_aes_256_sha", false);
  pref("security.ssl3.rsa_aes_128_sha", true);
- pref("security.ssl3.rsa_aes_256_sha", true);
- pref("security.ssl3.rsa_aes_128_gcm_sha256", true);
- pref("security.ssl3.rsa_aes_256_gcm_sha384", true);
--pref("security.ssl3.rsa_des_ede3_sha", true);
-+pref("security.ssl3.rsa_des_ede3_sha", false);
- 
- pref("security.content.signature.root_hash",
-      "97:E8:BA:9C:F1:2F:B3:DE:53:CC:42:A4:E6:57:7E:D6:4D:F4:93:C2:47:B4:14:FE:A0:36:81:8D:38:23:56:0E");


### PR DESCRIPTION
Remove the weaker CBC-mode ECDSA ciphers:
`TLS_ECDHE_ECDSA_WITH_AES_256_CBC_SHA`
`TLS_ECDHE_ECDSA_WITH_AES_128_CBC_SHA`

While the RSA equivilants of these ciphers are still widely used, the ECDSA ones aren't and were [disabled in Chromium in 2016](https://bugs.chromium.org/p/chromium/issues/detail?id=658341).